### PR TITLE
rinfos/rwarns/rerrs fix

### DIFF
--- a/appconfig/vim/dotvim/UltiSnips/cpp.snippets
+++ b/appconfig/vim/dotvim/UltiSnips/cpp.snippets
@@ -292,9 +292,11 @@ if is_plugin:
 	snip.rv='['+get_class_name()+']'
 elif is_gazebo_plugin:
 	snip.rv='['+get_gazebo_plugin_class_name()+']'
+elif (match.group(2) == "s") or (match.group(3) == "s") :
+	snip.rv="[\" << ros::this_node::getName().c_str() << \"]"
 else:
 	snip.rv="[%s]"`: ${1}"`!p
-if not is_plugin and not is_gazebo_plugin:
+if not is_plugin and not is_gazebo_plugin and not ((match.group(2) == "s") or (match.group(3) == "s")) :
 	snip.rv=", ros::this_node::getName().c_str()"``!p
 if "%" in t[1]:
 	snip.rv=", "


### PR DESCRIPTION
The `ROS_**_STREAM` printing needed different way of adding node header - `"[%s]:"` does not work with the streaming concatenation used therein.
Now, typing e.g. `rinfos [TAB]` calls snippet that inserts the node name with the streaming operators between two brackets.
![image](https://github.com/klaxalk/linux-setup/assets/21334530/00d6fffc-7ae6-45e4-b054-a4994d8b50c2)

BTW: `sinfo` does this:
![image](https://github.com/klaxalk/linux-setup/assets/21334530/ed21b4cd-1e0c-4b68-a618-8d8f82cf0f1e)

